### PR TITLE
fix ssl:getopts

### DIFF
--- a/src/mochicow_request.erl
+++ b/src/mochicow_request.erl
@@ -234,7 +234,7 @@ raw_recv(Timeout, Tries) ->
 getopts(Opts) ->
     case Socket of
         {ssl, _Socket} ->
-            ssl:getopts(Socket, Opts);
+            ssl:getopts(_Socket, Opts);
         _ ->
             inet:getopts(Socket, Opts)
     end.

--- a/src/mochicow_request.erl
+++ b/src/mochicow_request.erl
@@ -233,7 +233,7 @@ raw_recv(Timeout, Tries) ->
 
 getopts(Opts) ->
     case Socket of
-        {ssl, Socket} ->
+        {ssl, _Socket} ->
             ssl:getopts(Socket, Opts);
         _ ->
             inet:getopts(Socket, Opts)


### PR DESCRIPTION
in ssl configuration we never go to ssl:getopts we go always on inet:getops

{function_clause,
[{prim_inet,getopts,
[{ssl,{sslsocket,new_ssl,}},[packet,packet_size]],
[]},
{mochicow_request,recv,3,[{file,"src/mochicow_request.erl"},{line,168}]},
{mochicow_request,stream_unchunked_body,4,
[{file,"src/mochicow_request.erl"},{line,568}]},
{mochicow_request,recv_body,2,
[{file,"src/mochicow_request.erl"},{line,274}]},
{mochicow_request,parse_post,1,
[{file,"src/mochicow_request.erl"},{line,527}]},
{simple_bridge_request_wrapper,post_param,2,
[{file,"src/simple_bridge_request_wrapper.erl"},{line,58}]},
{dashboard_security_controller,index,3,
[{file,
"/var/www/dashboard/src/controller/dashboard_security_controller.erl"},
{line,26}]},
{boss_web_controller,execute_action,5,
[{file,"src/boss/boss_web_controller.erl"},{line,711}]}]}
